### PR TITLE
Remove defer to handle new containerregistry limiter

### DIFF
--- a/pkg/buildpacks/download.go
+++ b/pkg/buildpacks/download.go
@@ -97,15 +97,20 @@ func removeDuplicates(buildpacks []buildpack.BuildModule) []buildpack.BuildModul
 
 func extractBuildpacks(buildpacks []buildpack.BuildModule, dir string) error {
 	for _, bp := range buildpacks {
-		reader, err := bp.Open()
+		err := extractBuildpack(bp, dir)
 		if err != nil {
-			return err
-		}
-		defer reader.Close()
-
-		if err := archive.ExtractWithBaseOverride(reader, dist.BuildpacksDir, dir); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func extractBuildpack(bp buildpack.BuildModule, dir string) error {
+	reader, err := bp.Open()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	return archive.ExtractWithBaseOverride(reader, dist.BuildpacksDir, dir)
 }


### PR DESCRIPTION
`go-containerregistry` introduces a [limiter](https://github.com/google/go-containerregistry/blob/main/pkg/v1/remote/limiter.go) in the latest patch version which results in a deadlock when it needs to spawn more than 4 jobs. This enables bumping https://github.com/cloudfoundry/cnbapplifecycle/pull/165